### PR TITLE
Create bash_script_generator

### DIFF
--- a/bash_script_generator
+++ b/bash_script_generator
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+###################################################################
+#SCRIPT NAME:   bash_script_generator.sh                                                                                 
+#DESCRIPTION:   This script automatically creates a bash script and
+#               write header for the script.
+#USAGE:         bash bash_script_generator.sh NEW_SCRIPT_NAME AUTHOR EMAIL
+#               You can also set an alias named 'mksc' for the script
+#               to use it easily. For this purpose edit and add the
+#               following line to your basrc/zshrc:
+#               alias mksc='bash /PATH/TO/SCRIPT/bash_script_generator.sh AUTHOR EMAIL'
+#REQUIREMENTS:  vim
+#AUTHOR:        Isin Altinkaya                                                
+#EMAIL:         isinaltinkaya@gmail.com                                           
+###################################################################
+
+# the desired name of the new bash script 
+SCRIPT_ID=$1
+AUTHOR=$2
+EMAIL=$3
+
+SCRIPT=${SCRIPT_ID}.sh
+
+touch $SCRIPT
+
+cat > "$SCRIPT" << EOF
+#!/bin/bash
+
+###################################################################
+#SCRIPT NAME:   ${SCRIPT}                                                                                 
+#DESCRIPTION:
+#USAGE:         bash ${SCRIPT}
+#REQUIREMENTS:
+#AUTHOR:        ${AUTHOR}                                                
+#EMAIL:         ${EMAIL}                                
+###################################################################
+
+
+EOF
+
+vim $SCRIPT -c ":12"


### PR DESCRIPTION
This script automatically creates a bash script and write header for the script.

Usage:
bash bash_script_generator.sh NEW_SCRIPT_NAME AUTHOR EMAIL

You can also set an alias named 'mksc' for the script to use it easily. For this purpose edit and add the following line to your basrc/zshrc:

alias mksc='bash /PATH/TO/SCRIPT/bash_script_generator.sh AUTHOR EMAIL'

Requirements:  vim