### PR TITLE
Fixed two issues

### DIFF
--- a/file_organizer/README.md
+++ b/file_organizer/README.md
@@ -11,7 +11,7 @@ Just open your command line tools and run the python scripts followed by the dir
 ## Specification
 For this version, the files will be grouped into these folders based on the file format:
 
-* Documents (.pdf, .docx, .xlsx, .doc, .odt, .ipynb, .md, .csv)
+* Documents (.pdf, .docx, .xlsx, .doc, .odt, .ipynb, .md, .csv, pptx, ppt)
 * Videos (.mp4, .avi, .3gp, .mpg, .mov, .mkv, .m4v, .flv)
 * Audios (.mp3, .wav, .ogg)
 * Images (.jpg, .jpeg, .png)

--- a/file_organizer/README.md
+++ b/file_organizer/README.md
@@ -7,7 +7,7 @@ Just open your command line tools and run the python scripts followed by the dir
 **Example**:
 
     python3 FileOrganizer.py <directory>
-
+    <directory> value example - C:\Users\user-pc\Downloads\
 ## Specification
 For this version, the files will be grouped into these folders based on the file format:
 

--- a/file_organizer/file_organizer.py
+++ b/file_organizer/file_organizer.py
@@ -2,7 +2,7 @@ import os
 import shutil
 import sys
 
-docs = ['pdf','docx','xlsx','doc','odt','ipynb','md','csv']
+docs = ['pdf','docx','xlsx','doc','odt','ipynb','md','csv','pptx','ppt']
 torrent = ['torrent']
 image = ['jpg','png','bmp']
 video = ['mp4','avi','3gp','mpg','mov','mkv','m4v','flv']

--- a/file_organizer/file_organizer.py
+++ b/file_organizer/file_organizer.py
@@ -9,7 +9,7 @@ video = ['mp4','avi','3gp','mpg','mov','mkv','m4v','flv']
 audio = ['mp3','wav','ogg']
 
 def group_files(path,filename):
-    file_format = filename.split('.')[1].lower()
+    file_format = filename.split('.')[-1].lower()
     if file_format in docs:
         folder = 'Documents'
     elif file_format in torrent:
@@ -33,6 +33,7 @@ if (len(sys.argv) != 2):
     print('Wrong command! Please use format "python3 FileOrganizer.py <directory to organize>"')
 else:    
     path = sys.argv[1]
+    os.chdir(path)
     files = filter(os.path.isfile, os.listdir( os.curdir ) )  # files only
     files = [ f for f in os.listdir( os.curdir ) if os.path.isfile(f) ] #list comprehension version
 


### PR DESCRIPTION
First issue is that the os uses the scripts location as the execution folder, I changed so that it will change the directory to the directory that is given as an argument.
Second issue is that files with dots in their names get a wrong file extension( i.g. "songSong 28.7.1888.mp3" will be recognized as 28 or 7), I changed the script to take the substring that is after the last dot and it fixed it.